### PR TITLE
Fixes Minor Meme Card Styling Issues

### DIFF
--- a/src/app/community/browse/browse.component.html
+++ b/src/app/community/browse/browse.component.html
@@ -5,6 +5,7 @@
                      [username]="u.un"
                      [image]="u.img"
                      [imageHeight]="u.height"
+                     [style.marginLeft.px]="utils.isMobile ? 0 : 10"
       ></app-meme-card>
     </div>
   </mat-tab>

--- a/src/app/community/browse/browse.component.scss
+++ b/src/app/community/browse/browse.component.scss
@@ -13,7 +13,6 @@
 
 .flexItem {
   flex-basis: auto;
-  margin-left: 10px;
   margin-top: 10px;
 }
 

--- a/src/app/meme-card/meme-card.component.html
+++ b/src/app/meme-card/meme-card.component.html
@@ -1,5 +1,5 @@
 <mat-card class="meme-card">
-  <img class="meme-img" [style.maxHeight.px]="checkHeight(imageHeight)" [style.minWidth.px]="minCardWidth(imageHeight)"
+  <img class="meme-img" [style.height.px]="checkHeight(imageHeight)" [style.minWidth.px]="minCardWidth(imageHeight)"
        [style.maxWidth.px]="maxCardWidth(imageHeight)" [src]="image">
   <!-- Actions that are appended to the bottom of the card: show author name, up vote, down vote-->
   <mat-card-content class="actions" style="margin-top: -3px;">


### PR DESCRIPTION
* Removes margin left on meme cards when mobile (is now centered)
* Ensures the meme card is always scaled to the specified height even if it is smaller in terms of pixels