### PR TITLE
Fixes Search Bar Styling

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -7,11 +7,11 @@
   <span class="fill-remaining-space"></span>
 
 
-  <app-header-search></app-header-search>
+  <app-header-search style="margin-right: 10px;"></app-header-search>
   <button mat-button (click)="registerPage()" *ngIf="!userService.isLoggedIn()">Sign Up</button>
   <button mat-raised-button color="accent" (click)="loginPage()" *ngIf="!userService.isLoggedIn()">Log in</button>
 
   <p id="username" (click)="gotoProfile()" *ngIf="userService.isLoggedIn()">{{userService.user.username}}</p>
   <button mat-raised-button color="accent" (click)="logout()" *ngIf="userService.isLoggedIn()">Log out</button>
-  
+
 </mat-toolbar>

--- a/src/app/search/search-bar/search-bar.component.html
+++ b/src/app/search/search-bar/search-bar.component.html
@@ -1,20 +1,19 @@
-<mat-card class="search-card">
-  <input #query matInput
-         type="search"
-         placeholder="Search"
-         (keyup)="onKey(query.value)"
-         [matAutocomplete]="auto">
-  <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
-    <mat-optgroup *ngIf="options.communities && options.communities.length > 0" label="Communities">
-      <mat-option *ngFor="let community of options.communities" [value]="community">
-        {{ community.name }} - {{community.title}}
-      </mat-option>
-    </mat-optgroup>
-    <mat-optgroup *ngIf="options.users && options.users.length > 0" label="Users">
-      <mat-option *ngFor="let user of options.users" [value]="user">
-        {{ user.username }}
-      </mat-option>
-    </mat-optgroup>
-  </mat-autocomplete>
-</mat-card>
+<input #query matInput
+       class="mat-elevation-z2"
+       type="search"
+       placeholder="Search"
+       (keyup)="onKey(query.value)"
+       [matAutocomplete]="auto">
+<mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFn">
+  <mat-optgroup *ngIf="options.communities && options.communities.length > 0" label="Communities">
+    <mat-option *ngFor="let community of options.communities" [value]="community">
+      {{ community.name }} - {{community.title}}
+    </mat-option>
+  </mat-optgroup>
+  <mat-optgroup *ngIf="options.users && options.users.length > 0" label="Users">
+    <mat-option *ngFor="let user of options.users" [value]="user">
+      {{ user.username }}
+    </mat-option>
+  </mat-optgroup>
+</mat-autocomplete>
 

--- a/src/app/search/search-bar/search-bar.component.scss
+++ b/src/app/search/search-bar/search-bar.component.scss
@@ -3,3 +3,15 @@
   display: inline-flex;
   width: inherit;
 }
+
+input {
+  border: solid 1px rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
+  outline: none;
+  padding: 6px;
+
+  width: inherit;
+
+  font-size: 16px;
+  line-height: 20px;
+}

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {MatAutocompleteModule, MatInputModule, MatCardModule, MatButtonModule, MatIconModule, MatDialogModule} from '@angular/material';
+import {MatAutocompleteModule, MatInputModule, MatButtonModule, MatIconModule, MatDialogModule} from '@angular/material';
 import { SearchBarComponent } from './search-bar/search-bar.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MobileSearchDialogComponent } from './mobile-search-dialog/mobile-search-dialog.component';
@@ -11,7 +11,6 @@ import { HeaderSearchComponent } from './header-search/header-search.component';
     CommonModule,
     MatAutocompleteModule,
     MatInputModule,
-    MatCardModule,
     MatButtonModule,
     MatIconModule,
     MatDialogModule,


### PR DESCRIPTION
* The `matInput` search bar seems to be wacky when outside a `mat-form-field` so this PR removes the `matInput` directive and styles the input manually
* Fixes a bug where the `matInput` styling would strangely load only on pages where another matInput inside a mat-form-field is
![image](https://user-images.githubusercontent.com/11811793/38516554-bcf3030a-3bf4-11e8-820c-56466f217178.png)

![image](https://user-images.githubusercontent.com/11811793/38516580-cc30f340-3bf4-11e8-986f-3a303c6fb820.png)
