### PR TITLE
Hooks Up Community Creation Form to Server

### DIFF
--- a/src/app/api/community.service.ts
+++ b/src/app/api/community.service.ts
@@ -35,9 +35,10 @@ export class CommunityService {
   }
 
   getCommunities(sort: string, count: number, offset: number): Promise<CommunityList> {
-    return this.api.get(Version.v1, `communities?sort=${sort}&count=${count}&offset=${offset}`).then((communitiesList: CommunityList) => {
-      return communitiesList;
-    });
+    return this.api.get(Version.v1, `communities?sort=${sort}&count=${count}&offset=${offset}`)
+      .then((communitiesList: CommunityList) => {
+        return communitiesList;
+      });
   }
 
   getCommunityDetails(name: string): Promise<Community> {
@@ -64,9 +65,10 @@ export class CommunityService {
   }
 
   getCommunityTemplates(name: string, sort: string, offset: number, count: number): Promise<TemplateList> {
-    return this.api.get(Version.v1, `communities/${name}/templates?sort=${sort}&offset=${offset}&count=${count}`).then((templatesList: TemplateList) => {
-      return templatesList;
-    });
+    return this.api.get(Version.v1, `communities/${name}/templates?sort=${sort}&offset=${offset}&count=${count}`)
+      .then((templatesList: TemplateList) => {
+        return templatesList;
+      });
   }
 
   isCommunityNameAvailable(name: string): Promise<boolean> {

--- a/src/app/api/community.service.ts
+++ b/src/app/api/community.service.ts
@@ -31,7 +31,7 @@ export class CommunityService {
   constructor(private api: BaseApiService) { }
 
   createCommunity(community: Community): Promise<Community> {
-    return this.api.post(Version.v1, 'communities', community);
+    return this.api.post(Version.v1, 'communities', community) as Promise<Community>;
   }
 
   getCommunities(sort: string, count: number, offset: number): Promise<CommunityList> {

--- a/src/app/api/community.service.ts
+++ b/src/app/api/community.service.ts
@@ -7,7 +7,6 @@ export interface Community {
   description?: string;
   sidebar?: string;
   nsfw?: boolean;
-  creatorId: number;
 }
 
 export interface CommunityList {
@@ -31,7 +30,7 @@ export class CommunityService {
 
   constructor(private api: BaseApiService) { }
 
-  createCommunity(community: Community): Promise<any> {
+  createCommunity(community: Community): Promise<Community> {
     return this.api.post(Version.v1, 'communities', community);
   }
 

--- a/src/app/api/community.service.ts
+++ b/src/app/api/community.service.ts
@@ -71,8 +71,8 @@ export class CommunityService {
   }
 
   isCommunityNameAvailable(name: string): Promise<boolean> {
-    return this.api.get(Version.v1, `${name}/exists`).then((exists: boolean) => {
-      return exists;
+    return this.api.get(Version.v1, `communities/${name}/exists`).then((data: {exists: boolean}) => {
+      return data.exists;
     });
   }
 }

--- a/src/app/community/community.module.ts
+++ b/src/app/community/community.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { BrowseComponent } from './browse/browse.component';
 import { MemeCardComponent } from '../meme-card/meme-card.component';
 import { CreateComponent } from './create/create.component';
-import { MatTabsModule, MatIconModule, MatCardModule, MatButtonModule } from '@angular/material';
+import {MatTabsModule, MatIconModule, MatCardModule, MatButtonModule, MatTooltipModule} from '@angular/material';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -22,6 +22,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
     ReactiveFormsModule,
     FormsModule,
     MatCheckboxModule,
+    MatTooltipModule
   ],
   declarations: [BrowseComponent, MemeCardComponent, CreateComponent]
 })

--- a/src/app/community/community.module.ts
+++ b/src/app/community/community.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { BrowseComponent } from './browse/browse.component';
 import { MemeCardComponent } from '../meme-card/meme-card.component';
 import { CreateComponent } from './create/create.component';
-import {MatTabsModule, MatIconModule, MatCardModule, MatButtonModule, MatTooltipModule} from '@angular/material';
+import {MatTabsModule, MatIconModule, MatCardModule, MatButtonModule, MatTooltipModule, MatSnackBarModule} from '@angular/material';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -22,7 +22,8 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
     ReactiveFormsModule,
     FormsModule,
     MatCheckboxModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatSnackBarModule
   ],
   declarations: [BrowseComponent, MemeCardComponent, CreateComponent]
 })

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -26,7 +26,7 @@
       </mat-form-field>
 
       <mat-form-field>
-        <input matInput placeholder="Sidebar Message" formControlName="sidebar" maxlength="300">
+        <textarea matInput placeholder="Sidebar Message" formControlName="sidebar" rows="3"></textarea>
       </mat-form-field>
 
        <mat-checkbox matTooltip="Not Suitable for Work">NSFW</mat-checkbox>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -1,5 +1,5 @@
 <mat-card class="communityCreationForm">
-  <mat-card-title>Community Creation</mat-card-title>
+  <mat-card-title>Create Community</mat-card-title>
 
   <mat-card-content>
     <form [formGroup]="form">

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -17,7 +17,7 @@
         <mat-error *ngIf="form.get('name').hasError('nameExists')">
           That name is already taken
         </mat-error>
-        <mat-hint *ngIf="form.get('name').valid">meme.place/p/{{form.get('name').value}}</mat-hint>
+        <mat-hint *ngIf="form.get('name').valid">meme.place/p/{{form.get('name').value}} is available!</mat-hint>
         <mat-hint align="end">Required</mat-hint>
       </mat-form-field>
 

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -43,7 +43,7 @@
 
   <mat-card-actions>
     <button mat-raised-button id="submitButton" color="primary" (click)="onCreateCommunity()"
-            [disabled]="form.status != 'VALID'">Create Community</button>
+            [disabled]="form.status != 'VALID' || submitting">Create Community</button>
   </mat-card-actions>
 
 </mat-card>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -2,32 +2,38 @@
   <mat-card-title>Community Creation</mat-card-title>
 
   <mat-card-content>
-    <mat-form-field id="communityNameField">
-      <input matInput placeholder="Name (shorthand form, used in URL)" [formControl]="nameFormControl" [(ngModel)]="nameText" maxlength="25" >
-      <mat-error *ngIf="nameFormControl.hasError('required')">
-        Name is <strong>required</strong>
-      </mat-error>
-    </mat-form-field>
+    <form [formGroup]="form">
+      <mat-form-field>
+        <input matInput type="text" placeholder="Name (shorthand form, used in URL)" formControlName="name" maxlength="25" >
+        <mat-error *ngIf="form.get('name').hasError('required')">
+          Name is <strong>required</strong>
+        </mat-error>
+        <mat-error *ngIf="form.get('name').hasError('minlength')">
+          Name must be at least 3 characters
+        </mat-error>
+        <mat-hint *ngIf="form.get('name').valid">meme.place/p/{{form.get('name').value}}</mat-hint>
+      </mat-form-field>
 
-    <mat-form-field id="communityTitleField">
-      <input matInput placeholder="Title" [formControl]="titleFormControl" [(ngModel)]="titleText" maxlength="100">
-      <mat-error *ngIf="titleFormControl.hasError('required')">
-        Community Title is <strong>required</strong>
-      </mat-error>
-    </mat-form-field>
+      <mat-form-field>
+        <input matInput placeholder="Title" formControlName="title" maxlength="100">
+        <mat-error *ngIf="form.get('title').hasError('required')">
+          Community Title is <strong>required</strong>
+        </mat-error>
+      </mat-form-field>
 
-    <mat-form-field id="comDescriptionField">
-      <textarea matInput placeholder="Description" [(ngModel)] = "descriptionText" rows="10"></textarea>
-    </mat-form-field>
+      <mat-form-field>
+        <textarea matInput placeholder="Description" formControlName="description" rows="3"></textarea>
+      </mat-form-field>
 
-    <mat-form-field id="sidebarTextField">
-      <input matInput placeholder="Sidebar Message" [(ngModel)]="sidebarText" maxlength="300">
-    </mat-form-field>
+      <mat-form-field>
+        <input matInput placeholder="Sidebar Message" formControlName="sidebar" maxlength="300">
+      </mat-form-field>
 
+       <mat-checkbox matTooltip="Not Suitable for Work">NSFW</mat-checkbox>
+    </form>
   </mat-card-content>
 
   <mat-card-actions>
-    <mat-checkbox [(ngModel)]="NSFW_checked">NSFW</mat-checkbox>
     <button mat-raised-button id="submitButton" color="primary" (click)="onCreateCommunity()"
             [disabled]="!(!nameFormControl.hasError('required') && !titleFormControl.hasError('required'))">Create Community</button>
   </mat-card-actions>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -15,6 +15,7 @@
           That name is already taken
         </mat-error>
         <mat-hint *ngIf="form.get('name').valid">meme.place/p/{{form.get('name').value}}</mat-hint>
+        <mat-hint align="end">Required</mat-hint>
       </mat-form-field>
 
       <mat-form-field>
@@ -22,6 +23,7 @@
         <mat-error *ngIf="form.get('title').hasError('required')">
           Community Title is <strong>required</strong>
         </mat-error>
+        <mat-hint align="end">Required</mat-hint>
       </mat-form-field>
 
       <mat-form-field>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -40,7 +40,7 @@
 
   <mat-card-actions>
     <button mat-raised-button id="submitButton" color="primary" (click)="onCreateCommunity()"
-            [disabled]="form.invalid">Create Community</button>
+            [disabled]="form.status != 'VALID'">Create Community</button>
   </mat-card-actions>
 
 </mat-card>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -34,7 +34,7 @@
         <textarea matInput placeholder="Sidebar Message" formControlName="sidebar" rows="3"></textarea>
       </mat-form-field>
 
-       <mat-checkbox matTooltip="Not Suitable for Work">NSFW</mat-checkbox>
+       <mat-checkbox matTooltip="Not Suitable for Work" formControlName="nsfw">NSFW</mat-checkbox>
     </form>
   </mat-card-content>
 

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -44,6 +44,7 @@
   <mat-card-actions>
     <button mat-raised-button id="submitButton" color="primary" (click)="onCreateCommunity()"
             [disabled]="form.status != 'VALID' || submitting">Create Community</button>
+    <div style="clear: both;"></div>
   </mat-card-actions>
 
 </mat-card>

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -4,12 +4,15 @@
   <mat-card-content>
     <form [formGroup]="form">
       <mat-form-field>
-        <input matInput type="text" placeholder="Name (shorthand form, used in URL)" formControlName="name" maxlength="25" >
+        <input matInput type="text" placeholder="Name (shorthand form, used in URL)" formControlName="name" maxlength="25" pattern="[a-zA-Z0-9]*">
         <mat-error *ngIf="form.get('name').hasError('required')">
           Name is <strong>required</strong>
         </mat-error>
         <mat-error *ngIf="form.get('name').hasError('minlength')">
           Name must be at least 3 characters
+        </mat-error>
+        <mat-error *ngIf="form.get('name').hasError('pattern')">
+          The name can only contain alphanumeric characters without spaces
         </mat-error>
         <mat-error *ngIf="form.get('name').hasError('nameExists')">
           That name is already taken

--- a/src/app/community/create/create.component.html
+++ b/src/app/community/create/create.component.html
@@ -11,6 +11,9 @@
         <mat-error *ngIf="form.get('name').hasError('minlength')">
           Name must be at least 3 characters
         </mat-error>
+        <mat-error *ngIf="form.get('name').hasError('nameExists')">
+          That name is already taken
+        </mat-error>
         <mat-hint *ngIf="form.get('name').valid">meme.place/p/{{form.get('name').value}}</mat-hint>
       </mat-form-field>
 
@@ -35,7 +38,7 @@
 
   <mat-card-actions>
     <button mat-raised-button id="submitButton" color="primary" (click)="onCreateCommunity()"
-            [disabled]="!(!nameFormControl.hasError('required') && !titleFormControl.hasError('required'))">Create Community</button>
+            [disabled]="form.invalid">Create Community</button>
   </mat-card-actions>
 
 </mat-card>

--- a/src/app/community/create/create.component.scss
+++ b/src/app/community/create/create.component.scss
@@ -4,6 +4,7 @@
 
 mat-form-field {
   display: inherit;
+  margin-top: 10px;
 }
 
 

--- a/src/app/community/create/create.component.scss
+++ b/src/app/community/create/create.component.scss
@@ -7,4 +7,8 @@ mat-form-field {
   margin-top: 10px;
 }
 
+#submitButton {
+  float: right;
+}
+
 

--- a/src/app/community/create/create.component.scss
+++ b/src/app/community/create/create.component.scss
@@ -1,7 +1,5 @@
 .communityCreationForm {
   margin: 30px;
-  height: 65vh;
-  min-height: 500px;
 }
 
 mat-form-field {

--- a/src/app/community/create/create.component.scss
+++ b/src/app/community/create/create.component.scss
@@ -1,45 +1,11 @@
-textarea.mat-input-element {
-  resize: none;
-  overflow: auto;
-}
-
-mat-card-content {
-  display: flex;
-  flex-direction: column;
-}
-
 .communityCreationForm {
   margin: 30px;
   height: 65vh;
   min-height: 500px;
-  display: flex;
-  flex-direction: column;
-  position: relative;
 }
 
-.mat-card-actions {
-  margin-left: 0px;
-  margin-right: 0px;
-  padding: 30px 0;
+mat-form-field {
+  display: inherit;
 }
 
-#communityNameField {
-  border-top: 10px solid transparent;
-}
 
-#communityTitleField {
-  border-top: 10px solid transparent;
-}
-
-#comDescriptionField {
-  border-top: 10px solid transparent;
-}
-
-#sidebarTextField {
-  border-top: 10px solid transparent;
-}
-
-#submitButton {
-  width: 160px;
-  float: right;
-}

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -1,29 +1,23 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {CommunityService} from '../../api/community.service';
 
 @Component({
   selector: 'app-community-create',
   templateUrl: './create.component.html',
   styleUrls: ['./create.component.scss']
 })
-export class CreateComponent implements OnInit {
-  nameFormControl = new FormControl('', [
-    Validators.required,
-  ]);
-
-  titleFormControl = new FormControl('', [
-    Validators.required,
-  ]);
-
+export class CreateComponent {
+  private nameTimeout;
   form: FormGroup;
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder, private communityService: CommunityService) {
     this.createForm();
   }
 
   createForm() {
     this.form = this.fb.group({
-      name: ['', [Validators.required, Validators.minLength(3)]],
+      name: ['', [Validators.required, Validators.minLength(3)], [this.nameExists.bind(this)]],
       title: ['', Validators.required],
       description: [''],
       sidebar: [''],
@@ -32,7 +26,20 @@ export class CreateComponent implements OnInit {
     console.log(this.form);
   }
 
-  ngOnInit() {
+  nameExists(control: FormControl) {
+    clearTimeout(this.nameTimeout);
+
+    return new Promise((resolve, reject) => {
+      this.nameTimeout = setTimeout(() => {
+        this.communityService.isCommunityNameAvailable(control.value).then((exists) => {
+          if (exists) {
+            resolve({nameExists: true});
+          } else {
+            resolve(null);
+          }
+        }).catch((err) => resolve(null));
+      }, 250);
+    })
   }
 
   onCreateCommunity() {

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -25,8 +25,6 @@ export class CreateComponent {
       sidebar: '',
       nsfw: false
     });
-
-    console.log(this.form);
   }
 
   nameExists(control: FormControl) {

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
-import {CommunityService} from '../../api/community.service';
+import {Community, CommunityService} from '../../api/community.service';
+import {MatSnackBar} from '@angular/material';
 
 @Component({
   selector: 'app-community-create',
@@ -11,7 +12,7 @@ export class CreateComponent {
   private nameTimeout;
   form: FormGroup;
 
-  constructor(private fb: FormBuilder, private communityService: CommunityService) {
+  constructor(private fb: FormBuilder, private communityService: CommunityService, private snackBar: MatSnackBar) {
     this.createForm();
   }
 
@@ -46,5 +47,14 @@ export class CreateComponent {
   onCreateCommunity() {
     // pass nameText, titleText, and descriptionText to server
     console.log(this.form.value);
+    this.communityService.createCommunity(this.form.value as Community).then((community) => {
+      this.snackBar.open(`Created Community ${community.name}!`, 'Close', {
+        duration: 5000
+      });
+      
+      // TODO: Redirect to new community
+    }).catch((err) => {
+      this.snackBar.open(`Creation Failed: ${err.message}`, 'Close');
+    });
   }
 }

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -42,7 +42,7 @@ export class CreateComponent {
           }
         }).catch((err) => resolve(null));
       }, 250);
-    })
+    });
   }
 
   onCreateCommunity() {

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -11,6 +11,7 @@ import {MatSnackBar} from '@angular/material';
 export class CreateComponent {
   private nameTimeout;
   form: FormGroup;
+  submitting = false;
 
   constructor(private fb: FormBuilder, private communityService: CommunityService, private snackBar: MatSnackBar) {
     this.createForm();
@@ -45,8 +46,8 @@ export class CreateComponent {
   }
 
   onCreateCommunity() {
-    // pass nameText, titleText, and descriptionText to server
-    console.log(this.form.value);
+    this.submitting = true;
+
     this.communityService.createCommunity(this.form.value as Community).then((community) => {
       this.snackBar.open(`Created Community ${community.name}!`, 'Close', {
         duration: 5000
@@ -55,6 +56,8 @@ export class CreateComponent {
       // TODO: Redirect to new community
     }).catch((err) => {
       this.snackBar.open(`Creation Failed: ${err.message}`, 'Close');
+    }).then(() => {
+      this.submitting = false;
     });
   }
 }

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -19,8 +19,9 @@ export class CreateComponent {
     this.form = this.fb.group({
       name: ['', [Validators.required, Validators.minLength(3)], [this.nameExists.bind(this)]],
       title: ['', Validators.required],
-      description: [''],
-      sidebar: [''],
+      description: '',
+      sidebar: '',
+      nsfw: false
     });
 
     console.log(this.form);
@@ -44,5 +45,6 @@ export class CreateComponent {
 
   onCreateCommunity() {
     // pass nameText, titleText, and descriptionText to server
+    console.log(this.form.value);
   }
 }

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 
 @Component({
   selector: 'app-community-create',
@@ -7,12 +7,6 @@ import { FormControl, Validators } from '@angular/forms';
   styleUrls: ['./create.component.scss']
 })
 export class CreateComponent implements OnInit {
-  nameText: string;
-  titleText: string;
-  descriptionText: string;
-  sidebarText: string;
-  NSFW_checked: false;
-
   nameFormControl = new FormControl('', [
     Validators.required,
   ]);
@@ -21,7 +15,22 @@ export class CreateComponent implements OnInit {
     Validators.required,
   ]);
 
-  constructor() { }
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.createForm();
+  }
+
+  createForm() {
+    this.form = this.fb.group({
+      name: ['', [Validators.required, Validators.minLength(3)]],
+      title: ['', Validators.required],
+      description: [''],
+      sidebar: [''],
+    });
+
+    console.log(this.form);
+  }
 
   ngOnInit() {
   }

--- a/src/app/community/create/create.component.ts
+++ b/src/app/community/create/create.component.ts
@@ -51,7 +51,7 @@ export class CreateComponent {
       this.snackBar.open(`Created Community ${community.name}!`, 'Close', {
         duration: 5000
       });
-      
+
       // TODO: Redirect to new community
     }).catch((err) => {
       this.snackBar.open(`Creation Failed: ${err.message}`, 'Close');


### PR DESCRIPTION
* Restructures Form Building
* Adds Async custom validator for checking if the name exists while typing
* Adds regex pattern validation to name
* Community creation now successfully creates a community in the server with a little snackbar that shows status
* Slightly simplifies the CSS (please don't hate me @xiningchen, it was having conflicts with the user resizing the text areas)
* Disables submit button during submission
* Changes title to "Create Community" rather than "Community Creation"
* Adds hint for required fields from a glance

Closes #43 

TODO: Redirect to the newly created community when created