### PR TITLE
Caches Memes in Meme Service

### DIFF
--- a/src/app/api/meme.service.ts
+++ b/src/app/api/meme.service.ts
@@ -41,8 +41,7 @@ export class MemeService {
       if (isLoggedIn) {
         // destroy cache, we don't know how we voted on stuff
         this.memes = {};
-      }
-      else {
+      } else {
         // remove our votes
         Object.keys(this.memes).forEach((id) => {
           if (this.memes[id].myVote) {
@@ -63,7 +62,7 @@ export class MemeService {
    * @param {string} communityName
    * @return {Promise<Meme>} New meme details
    */
-  createMeme(title: string, link: string, width: number, height: number, templateId: number, communityName: string): Promise<Meme>{
+  createMeme(title: string, link: string, width: number, height: number, templateId: number, communityName: string): Promise<Meme> {
     return this.api.post(Version.v1, `memes`, {
       title: title,
       link: link,
@@ -80,8 +79,7 @@ export class MemeService {
     if (communityName) {
       result = await this.api.get(Version.v1,
         `communities/${communityName}/memes?sort=${sort}&offset=${offset}&count=${count}`) as Promise<MemeList>;
-    }
-    else {
+    } else {
       result = await this.api.get(Version.v1, `memes?sort=${sort}&offset=${offset}&count=${count}`) as Promise<MemeList>;
     }
 
@@ -98,7 +96,7 @@ export class MemeService {
    */
   async getMemeDetails(memeId: number): Promise<Meme> {
     if (this.memes[memeId]) {
-      return Promise.resolve(this.memes[memeId])
+      return Promise.resolve(this.memes[memeId]);
     }
 
     return this.api.get(Version.v1, `memes/${memeId}`).then( (meme: Meme) => {
@@ -144,7 +142,7 @@ export class MemeService {
    * @param {number} memeId
    */
   deleteMemeVote(memeId: number) {
-    return this.api.delete(Version.v1, `memes/${memeId}/vote`).then((value:({}|void)) => {
+    return this.api.delete(Version.v1, `memes/${memeId}/vote`).then((value: ({}|void)) => {
       if (this.memes[memeId]) {
         delete this.memes[memeId].myVote;
       }
@@ -156,7 +154,7 @@ export class MemeService {
    * @param {number} memeId
    */
   deleteMeme(memeId: number) {
-    return this.api.delete(Version.v1, `memes/${memeId}`).then((value:({}|void)) => {
+    return this.api.delete(Version.v1, `memes/${memeId}`).then((value: ({}|void)) => {
       if (this.memes[memeId]) {
         delete this.memes[memeId];
       }

--- a/src/app/api/meme.service.ts
+++ b/src/app/api/meme.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {BaseApiService, MessageReply, Version} from './base-api.service';
+import {UserService} from './user.service';
 
 export interface Meme {
   id: number;
@@ -34,7 +35,23 @@ export interface MemeList {
 export class MemeService {
   private memes: {[id: number]: Meme} = {};
 
-  constructor(private api: BaseApiService) {}
+  constructor(private api: BaseApiService,
+              private userService: UserService) {
+    userService.loggedIn$.subscribe((isLoggedIn) => {
+      if (isLoggedIn) {
+        // destroy cache, we don't know how we voted on stuff
+        this.memes = {};
+      }
+      else {
+        // remove our votes
+        Object.keys(this.memes).forEach((id) => {
+          if (this.memes[id].myVote) {
+            delete this.memes[id].myVote;
+          }
+        });
+      }
+    });
+  }
 
   /**
    * Creates a new meme


### PR DESCRIPTION
We can effectively reduce the amount of redundant requests by doing a little bit of caching in the meme service. On log out, the relevant meme votes are destroyed in the cache while logging in destroys the cache completely since we don't know how the user voted on those items.