### PR TITLE
Adds Travis Build YML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js # Building with node js
+node_js:
+  - stable # Download the stable node version
+
+cache:
+  directories:
+    - node_modules
+
+# Blocklist
+branches:
+  except:
+    - gh-pages # will be deployed to, no need to build it
+
+script:
+  - npm run build # Generates the dist folder with built angular app
+
+deploy:
+  provider: pages
+  skip_cleanup: true # Prevent travis from cleaning out the branch before the deploy occurs
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+      branch: master # Build only from master
+  local_dir: dist # Only copy the dist contents


### PR DESCRIPTION
* Automatically builds and deploys `master` to `gh-pages` which GitHub hosts using travis-ci