### PR TITLE
Adds Canvas Undo/Redo and Saves State in LocalStorage

### DIFF
--- a/src/app/creation/creation.component.html
+++ b/src/app/creation/creation.component.html
@@ -16,8 +16,11 @@
 </mat-grid-list>
 
 
-<div id="creation-body" (mousewheel)="onMouseWheel($event)">
-  <app-fabric #fab></app-fabric>
+<div id="creation-body"
+     (mousewheel)="onMouseWheel($event)"
+     (keyup.control.z)="fab.undo()"
+     (keyup.control.y)="fab.redo()">
+  <app-fabric #fab style="margin: auto;"></app-fabric>
 
   <div id="functionBar">
     <app-function-bar #functs></app-function-bar>

--- a/src/app/creation/creation.component.scss
+++ b/src/app/creation/creation.component.scss
@@ -1,14 +1,12 @@
-#creation-container {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-}
-
 #creation-body {
   height: calc(100% - (4em + 0px) + 0px);
   background: lightgrey;
   overflow: auto;
   text-align: center;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 #community-bar {

--- a/src/app/creation/fabric/fabric.component.html
+++ b/src/app/creation/fabric/fabric.component.html
@@ -2,7 +2,9 @@
      mwlResizable
      (resizeStart)="resizeStart()"
      (resizing)="onResize($event)"
-     [resizeEdges]="{bottom: true, right: true, top: true, left: true}">
+     [resizeEdges]="{bottom: true, right: true, top: true, left: true}"
+     (keyup.control.z)="undo()"
+     (keyup.control.y)="redo()">
   <canvas class="canvas" id="fabric"></canvas>
   <div mwlResizeHandle
        [resizeEdges]="{top: true}"

--- a/src/app/creation/fabric/fabric.component.html
+++ b/src/app/creation/fabric/fabric.component.html
@@ -3,9 +3,7 @@
      (resizeStart)="resizeStart()"
      (resizeEnd)="resizeEnd()"
      (resizing)="onResize($event)"
-     [resizeEdges]="{bottom: true, right: true, top: true, left: true}"
-     (keyup.control.z)="undo()"
-     (keyup.control.y)="redo()">
+     [resizeEdges]="{bottom: true, right: true, top: true, left: true}">
   <canvas class="canvas" id="fabric"></canvas>
   <div mwlResizeHandle
        [resizeEdges]="{top: true}"

--- a/src/app/creation/fabric/fabric.component.html
+++ b/src/app/creation/fabric/fabric.component.html
@@ -1,6 +1,7 @@
 <div #canvCont id="canvCont" tabindex="1"
      mwlResizable
      (resizeStart)="resizeStart()"
+     (resizeEnd)="resizeEnd()"
      (resizing)="onResize($event)"
      [resizeEdges]="{bottom: true, right: true, top: true, left: true}"
      (keyup.control.z)="undo()"

--- a/src/app/creation/fabric/fabric.component.ts
+++ b/src/app/creation/fabric/fabric.component.ts
@@ -354,8 +354,7 @@ export class FabricComponent {
   clearCanvas() {
     this.canvas.clear();
     this.canvas.setBackgroundColor('white');
-    this.history = this.toJSON();
-    this.historyPointer = 0;
+    this.save();
   }
 
   publish() {

--- a/src/app/creation/fabric/fabric.component.ts
+++ b/src/app/creation/fabric/fabric.component.ts
@@ -394,6 +394,7 @@ export class FabricComponent implements OnDestroy {
       }).then((meme) => {
         this.snackBar.open('Successfully created meme!', 'Close');
         this.parent.resetZoom();
+        this.clearCanvas();
         this.parent.title = '';
         this.parent.communityName = '';
       }).catch((err) => {

--- a/src/app/creation/fabric/fabric.component.ts
+++ b/src/app/creation/fabric/fabric.component.ts
@@ -81,7 +81,12 @@ export class FabricComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.storageService.setJSON(StorageType.local, 'canvas_state', this.toJSON());
+    if (this.canvas.getObjects().length === 0) {
+      this.storageService.remove(StorageType.local, 'canvas_state');
+    }
+    else {
+      this.storageService.setJSON(StorageType.local, 'canvas_state', this.toJSON());
+    }
   }
 
   /**


### PR DESCRIPTION
* Ctrl-Z to undo the canvas state, Ctrl-Y to redo
* Restores the canvas state, width, height, zoom, and pan on undo/redo
* Saves canvas state to local storage when navigating away, restores the state if it exists
* Centers canvas
* Clears canvas on meme publish, user can press undo to undo the clear

Closes #100, #105