### PR TITLE
Fixes Meme Card Layout Algo on Cards that Have a Larger Action Bar Than the Image Width

### DIFF
--- a/src/app/community/meme-view/meme-view.component.ts
+++ b/src/app/community/meme-view/meme-view.component.ts
@@ -27,6 +27,7 @@ export class MemeViewComponent implements OnInit, OnDestroy {
   memes: Meme[] = [];
   computedDimensions: Meme[] = [];
   maxRowHeight = 300;
+  minCardWidth = 200;
 
   maxAspectRatio = 3.0;
 
@@ -88,6 +89,12 @@ export class MemeViewComponent implements OnInit, OnDestroy {
         const i = Object.assign({}, meme.Image);
         if (i.width / i.height > this.maxAspectRatio) {
           i.width = i.height * this.maxAspectRatio;
+        }
+
+        // if we restricted the height, would the width be too small?
+        if (this.maxRowHeight / i.height * i.width < this.minCardWidth) {
+          // scale the original size to what it'd be if the smaller size was the min card width
+          i.width *= this.minCardWidth / (this.maxRowHeight / i.height * i.width);
         }
 
         return Object.assign(meme, {Image: i});

--- a/src/app/meme-card/meme-card.component.html
+++ b/src/app/meme-card/meme-card.component.html
@@ -1,6 +1,5 @@
-<mat-card class="meme-card">
+<mat-card class="meme-card" [style.width]="utils.isMobile ? '': imageWidth + 'px'">
   <img (click)="dialogPage()" class="meme-img" [style.height]="utils.isMobile ? '': imageHeight + 'px'"
-       [style.width]="utils.isMobile ? '95%': imageWidth + 'px'"
        [style.minWidth.px]="minCardWidth()" [style.maxWidth.px]="maxCardWidth(imageHeight)" [src]="imageLink">
   <!-- Actions that are appended to the bottom of the card: show author name, up vote, down vote-->
   <mat-card-content class="actions" style="margin-top: -3px;">
@@ -8,7 +7,8 @@
       {{username}}
     </span>
 
-    <div class="cardActionButtons">
+    <div style="flex: 1 1 auto;"></div>
+    <div class="vote">
       <!-- Up vote button -->
       <button mat-icon-button (click)="onClickUpVote()" [color]="myVote == 1 ? 'primary': 'basic'"><i
         class="material-icons">thumb_up</i></button>
@@ -16,7 +16,5 @@
       <!-- Down vote button -->
       <button mat-icon-button (click)="onClickDownVote()" [color]="myVote == -1 ? 'warn': 'basic'"><i class="material-icons">thumb_down</i></button>
     </div>
-
-    <div style="clear: both"></div>
   </mat-card-content>
 </mat-card>

--- a/src/app/meme-card/meme-card.component.html
+++ b/src/app/meme-card/meme-card.component.html
@@ -1,6 +1,8 @@
-<mat-card class="meme-card" [style.width]="utils.isMobile ? '': imageWidth + 'px'">
-  <img (click)="dialogPage()" class="meme-img" [style.height]="utils.isMobile ? '': imageHeight + 'px'"
-       [style.minWidth.px]="minCardWidth()" [style.maxWidth.px]="maxCardWidth(imageHeight)" [src]="imageLink">
+<mat-card class="meme-card" [style.width]="utils.isMobile ? '': imageWidth + 'px'" [style.minWidth.px]="minCardWidth()">
+  <img (click)="dialogPage()" class="meme-img"
+       [style.height]="utils.isMobile ? '': imageHeight + 'px'"
+       [style.maxHeight]="utils.isMobile ? '70vh': ''"
+       [style.maxWidth.px]="maxCardWidth(imageHeight)" [src]="imageLink">
   <!-- Actions that are appended to the bottom of the card: show author name, up vote, down vote-->
   <mat-card-content class="actions" style="margin-top: -3px;">
     <span class="author">

--- a/src/app/meme-card/meme-card.component.scss
+++ b/src/app/meme-card/meme-card.component.scss
@@ -9,16 +9,18 @@
   cursor: pointer;
 }
 
-.cardActionButtons {
-  float: right;
-}
-
 .author {
-  float: left;
   line-height: 40px; // Needed to vertical align
   vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .actions {
   padding: 0 5px 0 5px;
+  display: flex;
+}
+
+.vote {
+  white-space: nowrap;
 }


### PR DESCRIPTION
If the meme card width is computed to have a defined width but the action bar is bigger, the card will automatically increase in size to make sure the text is contained. This messes up the layout generator which relies on the width being displayed as exact.

* Forces the card to have a defined minimum-width during generation which is enforced in the UI card
* If the user's name exceeds the action bar width, it properly overflows with an ellipses. The minimum card width ensures the votes and thumbs up/down are always displayed regardless of author name length or image dimensions.
* Ensures the meme card height cannot be larger than 70% of the viewport on mobile