### PR TITLE
Fixes Font Loading for System Fonts

### DIFF
--- a/src/app/creation/function-bar/function-bar.component.scss
+++ b/src/app/creation/function-bar/function-bar.component.scss
@@ -1,4 +1,15 @@
-@import url('https://fonts.googleapis.com/css?family=Pacifico|VT323|Quicksand|Inconsolata|Impact|Roboto|Lora|Croissant One|Architects Daughter|Emblema One|Graduate|Hammersmith One|Oswald|Oxygen|Krona One|Indie Flower|Courgette|Gruppo|Ranchers');
+@import url('https://fonts.googleapis.com/css?family=Pacifico|VT323|Quicksand|Inconsolata|Roboto|Lora|Croissant One|Architects Daughter|Emblema One|Graduate|Hammersmith One|Oswald|Oxygen|Krona One|Indie Flower|Courgette|Gruppo|Ranchers');
+
+/* Aliases for Default Fonts to Prevent FontFaceObserver Errors */
+@font-face {
+  font-family: Impact;
+  src: local("Impact");
+}
+
+@font-face {
+  font-family: Arial;
+  src: local("Arial");
+}
 
 .sizeInput {
   width: 80px;


### PR DESCRIPTION
* Impact is not included as a font on Google Fonts and caused the endpoint to error out with 403 forbidden (nice error btw)
* Impact is included on most systems by default, so this PR aliases it with a font face to prevent fontfaceobserver from erroring out during preload