### PR TITLE
Fixes Canvas MouseWheel Zoom on Firefox

### DIFF
--- a/src/app/creation/creation.component.html
+++ b/src/app/creation/creation.component.html
@@ -17,7 +17,7 @@
 
 
 <div id="creation-body"
-     (mousewheel)="onMouseWheel($event)"
+     (wheel)="onMouseWheel($event)"
      (keyup.control.z)="fab.undo()"
      (keyup.control.y)="fab.redo()">
   <app-fabric #fab style="margin: auto;"></app-fabric>


### PR DESCRIPTION
* Firefox doesn't support the mousewheel event but rather the wheel event